### PR TITLE
Patch/renv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Run various tests on an NMTRAN dataset to validate it prior to mode
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Imports: 
     cli (>= 3.3.0),
     dplyr,

--- a/R/distinct-subject-columns.R
+++ b/R/distinct-subject-columns.R
@@ -24,7 +24,7 @@ distinct_subject_columns <- function(.data, .subject_col) {
     dplyr::pull(name)
 
   .data %>%
-    dplyr::select(all_of(c(.subject_col, unique_subject_columns))) %>%
+    dplyr::select(dplyr::all_of(c(.subject_col, unique_subject_columns))) %>%
     dplyr::distinct()
 
 }

--- a/R/distinct-subject-columns.R
+++ b/R/distinct-subject-columns.R
@@ -13,10 +13,10 @@ distinct_subject_columns <- function(.data, .subject_col) {
     .data %>%
     dplyr::mutate_all(as.character) %>%
     dplyr::mutate_all(~tidyr::replace_na(.x, "mrgda_NA")) %>%
-    dplyr::group_by(dplyr::across(.subject_col)) %>%
+    dplyr::group_by(!!sym(.subject_col)) %>%
     dplyr::summarise_all(~length(unique(.x))) %>%
     dplyr::ungroup() %>%
-    tidyr::pivot_longer(-.subject_col) %>%
+    tidyr::pivot_longer(-!!sym(.subject_col)) %>%
     dplyr::group_by(name) %>%
     dplyr::filter(all(value == 1)) %>%
     dplyr::ungroup() %>%
@@ -24,7 +24,7 @@ distinct_subject_columns <- function(.data, .subject_col) {
     dplyr::pull(name)
 
   .data %>%
-    dplyr::select(c(.subject_col, unique_subject_columns)) %>%
+    dplyr::select(all_of(c(.subject_col, unique_subject_columns))) %>%
     dplyr::distinct()
 
 }

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -1,37 +1,19 @@
 Version: 1
 
+Descriptions:
+  - DESCRIPTION
+
 Packages:
-  - assertr
-  - cli
-  - dplyr
-  - glue
-  - lifecycle
-  - magrittr
-  - purrr
-  - readr
-  - rlang
-  - tidyr
-  - withr
-  - yspec
   - devtools
-  - testthat
-  - pmtables
-  - covr
-  - markdown
-  - DT
-  - htmltools
-  - ggplot2
-  - mrggsave
-  - diffdf
-  - plotly
-  - progress
-  - mrgvalidate
+  - pkgdown
 
 Repos:
   - CRAN: https://cran.rstudio.com
-  - MPN: https://mpn.metworx.com/snapshots/stable/2022-08-31 # used for mrg packages
+  - MPN: https://mpn.metworx.com/snapshots/stable/2023-05-14 # used for mrg packages
 
-Lockfile:
-    Type: renv
+# Lockfile:
+#     Type: renv
+
+Library: /data/Projects/package_dev/temp_lib
 
 Rpath: ${R_EXE_4_1}

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -11,9 +11,7 @@ Repos:
   - CRAN: https://cran.rstudio.com
   - MPN: https://mpn.metworx.com/snapshots/stable/2023-05-14 # used for mrg packages
 
-# Lockfile:
-#     Type: renv
-
-Library: /data/Projects/package_dev/temp_lib
+Lockfile:
+    Type: renv
 
 Rpath: ${R_EXE_4_1}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,34 @@
+
+#' Creates a temporary directory for running svn commands
+#'
+#' Avoids `renv` issues associated with `tempdir()`
+#'
+#' @param clean Logical (`TRUE`/`FALSE`). Indicates if the temporary directory should be deleted after use
+#' @param env Environment to use for scoping
+#'
+#' @keywords internal
+local_svn_repo <- function(clean = TRUE, env = parent.frame()){
+  repo <- withr::local_tempdir("svn-test-repo",
+                               clean = clean,
+                               .local_envir = env
+  )
+  return(repo)
+}
+
+
+#' Helper function for executing code in a temporary directory
+#'
+#' Useful when you dont need to refer to the directory by name
+#'
+#' @param code Code to execute in the temporary environment
+#' @inheritParams local_svn_repo
+#'
+#' @keywords internal
+svn_repo_with_code <- function(code, clean = TRUE, env = parent.frame()) {
+  repo <- local_svn_repo(clean = clean, env = env)
+  if (isTRUE(clean)) {
+    withr::defer(unlink(repo, recursive = TRUE))
+  }
+
+  withr::with_dir(repo, code)
+}

--- a/tests/testthat/test-read-src-dir.R
+++ b/tests/testthat/test-read-src-dir.R
@@ -20,15 +20,15 @@ test_that("read_src_dir outputs a dataframe with labels from each domain", {
 
 test_that("read_src_dir works with a directory containing sas7bdat files", {
   dir <- tempdir()
-  haven::write_sas(mtcars, path = file.path(dir, "mtcars.sas7bdat"))
-  haven::write_sas(Theoph, path = file.path(dir, "theoph.sas7bdat"))
-  src_list2 <- read_src_dir(dir, .file_types = "sas7bdat")
+  haven::write_xpt(mtcars, path = file.path(dir, "mtcars.xpt"))
+  haven::write_xpt(Theoph, path = file.path(dir, "theoph.xpt"), label = NULL)
+  src_list2 <- read_src_dir(dir, .file_types = "xpt")
 
   expect_true(length(src_list2) == 4)
   expect_true(all(names(src_list2) %in% c("mtcars", "theoph", "mrgda_labels", "mrgda_src_meta")))
   expect_true(!is.null(src_list2$mtcars))
   expect_true(!is.null(src_list2$theoph))
-  expect_equal(src_list2$theoph, haven::read_sas(file.path(dir, "theoph.sas7bdat")) %>% suppressMessages())
+  expect_equal(src_list2$theoph, haven::read_xpt(file.path(dir, "theoph.xpt")) %>% suppressMessages())
 
 })
 

--- a/tests/testthat/test-read-src-dir.R
+++ b/tests/testthat/test-read-src-dir.R
@@ -19,7 +19,8 @@ test_that("read_src_dir outputs a dataframe with labels from each domain", {
 })
 
 test_that("read_src_dir works with a directory containing sas7bdat files", {
-  dir <- tempdir()
+  dir <- local_svn_repo()
+  withr::defer(unlink(dir, recursive = TRUE))
   haven::write_xpt(mtcars, path = file.path(dir, "mtcars.xpt"))
   haven::write_xpt(Theoph, path = file.path(dir, "theoph.xpt"), label = NULL)
   src_list2 <- read_src_dir(dir, .file_types = "xpt")

--- a/tests/testthat/test-write-derived.R
+++ b/tests/testthat/test-write-derived.R
@@ -1,11 +1,14 @@
 nm_spec <- yspec::ys_load(system.file("derived", "pk.yml", package = "mrgda"))
 nm <- readr::read_csv(system.file("derived", "pk.csv", package = "mrgda"), na = ".", show_col_types = FALSE)
 
-.temp_csv <- tempfile(fileext = ".csv")
-.temp_script <- tempfile(fileext = ".R")
+svn_dir <- local_svn_repo()
+withr::defer(unlink(svn_dir, recursive = TRUE))
+
+.temp_csv <- tempfile(fileext = ".csv", tmpdir = svn_dir)
+.temp_script <- tempfile(fileext = ".R", tmpdir = svn_dir)
 writeLines(text = "2 + 2", con = .temp_script)
 
-write_derived(.data = nm, .spec = nm_spec, .file = .temp_csv) %>% suppressMessages()
+write_derived(.data = nm, .spec = nm_spec, .file = .temp_csv, .compare_from_svn = FALSE) %>% suppressMessages()
 .csv_in <- readr::read_csv(.temp_csv, na = ".") %>% suppressMessages()
 .xpt_in_name <- paste0(gsub(".csv", "", .temp_csv, fixed = TRUE),
                        "/",
@@ -28,7 +31,7 @@ test_that("write_derived write xpt: xpt data includes correct labels [NMV-NMW-00
 
 test_that("write_derived works with special characters in file name [NMV-NMW-003]", {
   .temp_csv <- tempfile(fileext = "-pk.csv")
-  write_derived(.data = nm, .spec = nm_spec, .file = .temp_csv) %>% suppressMessages()
+  write_derived(.data = nm, .spec = nm_spec, .file = .temp_csv, .compare_from_svn = FALSE) %>% suppressMessages()
   expect_equal(nm, readr::read_csv(.temp_csv, na = ".") %>% suppressMessages())
 })
 


### PR DESCRIPTION
While reviewing PR https://github.com/metrumresearchgroup/mrgda/pull/126, we noticed a few issues when operating in an `renv` environment/using older package versions during development. This is highlighted [here](https://github.com/metrumresearchgroup/mrgda/pull/126#pullrequestreview-1506031972).

This PR addressed:
- Have `pkgr` point to the `DESCRIPTION` file
- update all `tidyselect` calls to silence warnings
- `haven::write_sas` was deprecated, and `haven::write_xpt` is suggested as the replacement during one of the tests. 
- Get the package to work with `renv`. Temporary directories created via `tempdir()` caused `renv` to copy over libraries, which messed up some `svn` tests and project-specific functions (functions that use `here::here()` to change the directory)

closes #127