### PR TITLE
change execute data diffs to return a list and not write out csvs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrgda
 Title: Validate NMTRAN datasets
-Version: 0.7.2.9000
+Version: 0.7.2.9001
 Authors@R: 
     c(
     person(given = "Eric", family = "Anderson", email = "andersone@metrumrg.com", role = c("aut", "cre")),

--- a/R/execute-data-diffs.R
+++ b/R/execute-data-diffs.R
@@ -5,24 +5,30 @@
 #'
 #' @param .base_df A data frame that serves as the base for comparison.
 #' @param .compare_df A data frame to compare against the base data frame.
-#' @param .output_dir A string representing the directory where the output difference files will be stored.
-#'        Set to `NULL` to skip saving output files.
-#' @param .id_col A string representing the column name to be used for subject-based differences.
-#'        Set to `NULL` for data frames not containing an ID column.
+#' @param .subject_col A string representing the column name to be used for subject-based differences.
+#'        Set to `NULL` for data frames not containing an subject column.
 #' @param .base_from_svn Logical. Was base df exported from svn?
 #'
 #' @return No return value, but this function will write files to the specified output directory
 #'         containing the differences between the input data frames.
 #'
 #' @export
-execute_data_diffs <- function(.base_df, .compare_df, .output_dir = NULL, .id_col = "ID", .base_from_svn = FALSE){
+execute_data_diffs <- function(.base_df, .compare_df, .subject_col, .base_from_svn = FALSE){
 
-  if(!is.null(.output_dir)){
-    if (!dir.exists(.output_dir)) {
-      stop(.output_dir, " does not exist")
-    }
+  # Exit if no names in common ----------------------------------------------
+  names_in_common <- dplyr::intersect(names(.base_df), names(.compare_df))
+
+  if (length(names_in_common) == 0) {
+    stop("The base and compare data frames do not have any columns to compare")
   }
 
+  out <- list()
+
+  # Initialize to empty data frames
+  out$diffs <- tibble::tribble(~name, ~value)
+
+  out$subject_diffs <-
+    tibble::tribble(~SUBJECT, ~VARIABLE, ~BASE, ~COMPARE,~`N Occurrences`)
 
   # Diffs across entire data ------------------------------------------------
   full_diff <- suppressMessages(
@@ -34,19 +40,10 @@ execute_data_diffs <- function(.base_df, .compare_df, .output_dir = NULL, .id_co
       strict_factor = FALSE
     )
   )
-  # cli::cli_alert_success(glue::glue("File written: {file.path(.output_dir, 'data-diff.txt')}"))
 
   if (length(full_diff) == 0) {
     cli::cli_alert_info("No diffs since last version found")
-
-    if(!is.null(.output_dir)){
-      readr::write_csv(
-        tibble::tribble(~name, ~value),
-        file.path(.output_dir, "diffs.csv")
-      )
-    }
-
-    return(invisible(NULL))
+    return(out)
   }
 
   cli::cli_alert_info("Diffs since last version:")
@@ -98,34 +95,6 @@ execute_data_diffs <- function(.base_df, .compare_df, .output_dir = NULL, .id_co
     )
   }
 
-
-  datas_have_id <- (.id_col %in% names(.base_df)) && (.id_col %in% names(.compare_df))
-
-  if(!datas_have_id && !is.null(.id_col)){
-    warning(glue::glue("The specified `.id_col` ({.id_col}) is not present in one or both of the data frames"))
-  }
-
-  datas_have_id <- (!is.null(.id_col)) && datas_have_id
-
-  if(datas_have_id){
-
-    n_id_diff <- length(unique(.compare_df[[.id_col]])) - length(unique(.base_df[[.id_col]]))
-
-    n_id_diff_msg <- dplyr::case_when(
-      n_id_diff == 0 ~ "No change in N IDs",
-      n_id_diff < 0 ~ paste0(gsub("-", "", as.character(n_id_diff), fixed=TRUE), " ID(s) removed"),
-      n_id_diff > 0 ~ paste0(n_id_diff, " ID(s) added")
-    )
-
-    print_diffs <- dplyr::bind_rows(
-      print_diffs,
-      tibble::tibble(
-        name = "N IDs Diff",
-        value = n_id_diff_msg
-      )
-    )
-  }
-
   print_diffs <- dplyr::bind_rows(
     print_diffs,
     tibble::tibble(
@@ -134,9 +103,49 @@ execute_data_diffs <- function(.base_df, .compare_df, .output_dir = NULL, .id_co
     )
   )
 
-  if(!is.null(.output_dir)){
-    readr::write_csv(print_diffs, file.path(.output_dir, "diffs.csv"))
+
+
+  if(is.null(.subject_col)){
+
+    out$diffs <- print_diffs
+
+    print(
+      cli::boxx(
+        padding = 0,
+        knitr::kable(
+          x = out$diffs,
+          align = 'c',
+          format = "simple"
+        )
+      )
+    )
+    return(out)
   }
+
+  datas_have_id <- (.subject_col %in% names(.base_df)) && (.subject_col %in% names(.compare_df))
+
+  if(!datas_have_id){
+    stop(glue::glue("The specified `.subject_col` ({.subject_col}) is not present in one or both of the data frames"))
+  }
+
+  n_id_diff <- length(unique(.compare_df[[.subject_col]])) - length(unique(.base_df[[.subject_col]]))
+
+  n_id_diff_msg <- dplyr::case_when(
+    n_id_diff == 0 ~ "No change in N IDs",
+    n_id_diff < 0 ~ paste0(gsub("-", "", as.character(n_id_diff), fixed=TRUE), " ID(s) removed"),
+    n_id_diff > 0 ~ paste0(n_id_diff, " ID(s) added")
+  )
+
+  print_diffs <- dplyr::bind_rows(
+    print_diffs,
+    tibble::tibble(
+      name = "N IDs Diff",
+      value = n_id_diff_msg
+    )
+  )
+
+  out$diffs <- print_diffs
+
 
   print(
     cli::boxx(
@@ -154,110 +163,57 @@ execute_data_diffs <- function(.base_df, .compare_df, .output_dir = NULL, .id_co
   .base_df$NUM <- NULL
   .compare_df$NUM <- NULL
 
-  # Only select names in common ---------------------------------------------
-  names_in_common <- dplyr::intersect(names(.base_df), names(.compare_df))
-
-  if (length(names_in_common) == 0) {
-    return(invisible(NULL))
-  }
-
-
   # Diffs by id -------------------------------------------------------------
+  id_diffs <- list()
+  ids <- unique(dplyr::intersect(.base_df[[.subject_col]], .compare_df[[.subject_col]]))
+  pb <- progress::progress_bar$new(total = length(ids))
 
-  if (datas_have_id) {
+  for (id.i in ids) {
 
-    id_diffs <- list()
-    ids <- unique(dplyr::intersect(.base_df[[.id_col]], .compare_df[[.id_col]]))
-    pb <- progress::progress_bar$new(total = length(ids))
+    base_df.i <-
+      .base_df[.base_df[[.subject_col]] == id.i, ] %>%
+      dplyr::select(dplyr::all_of(names_in_common))
 
-    for (id.i in ids) {
+    compare_df.i <-
+      .compare_df[.compare_df[[.subject_col]] == id.i, ] %>%
+      dplyr::select(dplyr::all_of(names_in_common))
 
-      base_df.i <-
-        .base_df[.base_df[[.id_col]] == id.i, ] %>%
-        dplyr::select(dplyr::all_of(names_in_common))
-
-      compare_df.i <-
-        .compare_df[.compare_df[[.id_col]] == id.i, ] %>%
-        dplyr::select(dplyr::all_of(names_in_common))
-
-      diff.i <-
-        suppressMessages(
-          diffdf::diffdf(
-            base = base_df.i,
-            compare = compare_df.i,
-            suppress_warnings = TRUE,
-            strict_numeric = FALSE,
-            strict_factor = FALSE
-          )
+    diff.i <-
+      suppressMessages(
+        diffdf::diffdf(
+          base = base_df.i,
+          compare = compare_df.i,
+          suppress_warnings = TRUE,
+          strict_numeric = FALSE,
+          strict_factor = FALSE
         )
+      )
 
-      if (length(diff.i) > 0) {
-        id_diffs[[as.character(id.i)]] <- diff.i
-      }
-
-      rm(diff.i)
-
-      pb$tick()
-
+    if (length(diff.i) > 0) {
+      id_diffs[[as.character(id.i)]] <- diff.i
     }
 
-    if (length(id_diffs) > 0) {
+    rm(diff.i)
 
-      id_diffs_out <- purrr::map_dfr(id_diffs, diffdf_value_changes_to_df, .id = .id_col)
+    pb$tick()
 
-      if (nrow(id_diffs_out) == 0) {
+  }
 
-        if(!is.null(.output_dir)){
+  if (length(id_diffs) > 0) {
 
-          readr::write_csv(
-            tibble::tribble(~ID, ~VARIABLE, ~BASE, ~COMPARE,~`N Occurrences`) %>% dplyr::rename(!!sym(.id_col) := "ID"),
-            file.path(.output_dir, 'id-diffs.csv')
-          )
+    id_diffs_out <- purrr::map_dfr(id_diffs, diffdf_value_changes_to_df, .id = .subject_col)
 
-        }
-        return(invisible(NULL))
-      }
+    if (nrow(id_diffs_out) > 0) {
 
-      id_diffs_out <-
+      out$subject_diffs <-
         id_diffs_out %>%
         dplyr::mutate_all(as.character) %>%
-        dplyr::group_by(!!sym(.id_col), VARIABLE, BASE, COMPARE) %>%
-        dplyr::summarise(`N Occurrences` = dplyr::n()) %>%
-        suppressMessages() %>%
-        dplyr::ungroup()
-
-      if(!is.null(.output_dir)){
-        data.table::fwrite(
-          x = id_diffs_out,
-          file = file.path(.output_dir, 'id-diffs.csv'),
-          sep = ",",
-          quote = FALSE,
-          row.names = FALSE,
-          na = "."
-        )
-      }
-
-      # cli::cli_alert_success(glue::glue("File written: {file.path(.output_dir, 'id-diffs.csv')}"))
-
-    }
-  }else{
-    id_diffs_out <- diffdf_value_changes_to_df(full_diff)
-    if(!is.null(id_diffs_out)){
-      id_diffs_out <- id_diffs_out %>%
-        dplyr::mutate_all(as.character) %>%
-        dplyr::group_by(VARIABLE, BASE, COMPARE) %>%
+        dplyr::group_by(!!sym(.subject_col), VARIABLE, BASE, COMPARE) %>%
         dplyr::summarise(`N Occurrences` = dplyr::n()) %>%
         suppressMessages() %>%
         dplyr::ungroup()
     }
   }
 
-  return(
-    invisible(
-      list(
-        summary_diffs = print_diffs,
-        variable_diffs = id_diffs_out
-      )
-    )
-  )
+  return(out)
 }

--- a/R/execute-data-diffs.R
+++ b/R/execute-data-diffs.R
@@ -108,6 +108,8 @@ execute_data_diffs <- function(.base_df, .compare_df, .subject_col, .base_from_s
   if(is.null(.subject_col)){
 
     out$diffs <- print_diffs
+    out$subject_diffs <- NULL
+    out$value_diffs <- diffdf_value_changes_to_df(full_diff)
 
     print(
       cli::boxx(

--- a/R/mrgda-package.R
+++ b/R/mrgda-package.R
@@ -58,7 +58,8 @@ globalVariables(
     "mrgda_SUBJ_NEED_ID",
     "MRGDA_ISSUE_ID",
     "MRGDA_PARSE_DATETIME",
-    "ID_SORT"
+    "ID_SORT",
+    ".output_dir"
   )
 )
 

--- a/R/write-derived.R
+++ b/R/write-derived.R
@@ -84,12 +84,30 @@ write_derived <- function(.data, .spec, .file, .prev_file = NULL, .compare_from_
   compare_df <- readr::read_csv(.file) %>% suppressMessages()
 
   if (!is.null(base_df_list$base_df) & .execute_diffs) {
-    execute_data_diffs(
-      .base_df = base_df_list$base_df,
-      .compare_df = compare_df,
-      .output_dir = .meta_data_folder,
-      .id_col = "ID",
-      .base_from_svn = base_df_list$from_svn
+    diffs <-
+      execute_data_diffs(
+        .base_df = base_df_list$base_df,
+        .compare_df = compare_df,
+        .subject_col = "ID",
+        .base_from_svn = base_df_list$from_svn
+      )
+
+    data.table::fwrite(
+      x = diffs$diffs,
+      file = file.path(.output_dir, 'diffs.csv'),
+      sep = ",",
+      quote = FALSE,
+      row.names = FALSE,
+      na = "."
+    )
+
+    data.table::fwrite(
+      x = diffs$subject_diffs,
+      file = file.path(.output_dir, 'subject-diffs.csv'),
+      sep = ",",
+      quote = FALSE,
+      row.names = FALSE,
+      na = "."
     )
   }
 
@@ -114,7 +132,7 @@ write_derived <- function(.data, .spec, .file, .prev_file = NULL, .compare_from_
 
   # Determine and save dependencies -----------------------------------------
   dependencies <- find_in_files(.paths = c(here::here("script"), here::here("model")), .string = basename(.file))
-  # yaml::write_yaml(dependencies, file = file.path(.meta_data_folder, "dependencies.yml"))
+  yaml::write_yaml(dependencies, file = file.path(.meta_data_folder, "dependencies.yml"))
 
   cli::cli_alert_success(glue::glue("File written: {.file}"))
   cli::cli_alert_success(glue::glue("File written: {file.path(.meta_data_folder, paste0(.data_name, '.xpt'))}"))

--- a/man/execute_data_diffs.Rd
+++ b/man/execute_data_diffs.Rd
@@ -4,24 +4,15 @@
 \alias{execute_data_diffs}
 \title{Execute Differences Between Data Frames}
 \usage{
-execute_data_diffs(
-  .base_df,
-  .compare_df,
-  .output_dir = NULL,
-  .id_col = "ID",
-  .base_from_svn = FALSE
-)
+execute_data_diffs(.base_df, .compare_df, .subject_col, .base_from_svn = FALSE)
 }
 \arguments{
 \item{.base_df}{A data frame that serves as the base for comparison.}
 
 \item{.compare_df}{A data frame to compare against the base data frame.}
 
-\item{.output_dir}{A string representing the directory where the output difference files will be stored.
-Set to \code{NULL} to skip saving output files.}
-
-\item{.id_col}{A string representing the column name to be used for subject-based differences.
-Set to \code{NULL} for data frames not containing an ID column.}
+\item{.subject_col}{A string representing the column name to be used for subject-based differences.
+Set to \code{NULL} for data frames not containing an subject column.}
 
 \item{.base_from_svn}{Logical. Was base df exported from svn?}
 }

--- a/tests/testthat/test-execute-data-diffs.R
+++ b/tests/testthat/test-execute-data-diffs.R
@@ -53,7 +53,8 @@ test_that("The function returns nothing if there are no diffs detected", {
 test_that("The function works if .suject_col is NULL", {
   lst <- execute_data_diffs(.base_df2, .compare_df2, .subject_col = NULL)
   expect_false(rlang::is_empty(lst$diffs))
-  expect_true(nrow(lst$subject_diffs) == 0)
+  expect_equal(lst$value_diffs$BASE[1], "2.5")
+  expect_true(is.null(lst$subject_diffs))
 
   x <-  try(execute_data_diffs(.base_df2, .compare_df2, .subject_col = "ID"), silent = TRUE)
 


### PR DESCRIPTION
This PR alters the functionality of execute_data_diffs to return a list of diffs, rather than either write out the csvs of the diffs, or return a list.

This change affected write_derived, which uses execute_data_diffs under the hood. write_derived will now take the list from execute_data_diffs and write out the csv files itself.