### PR TITLE
use rprojroot instead of here

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrgda
 Title: Tools for Data Assembly
-Version: 0.11.0.8002
+Version: 0.11.0.8003
 Authors@R: 
     c(
     person(given = "Eric", family = "Anderson", email = "andersone@metrumrg.com", role = c("aut", "cre")),
@@ -14,7 +14,7 @@ BugReports: https://github.com/metrumresearchgroup/mrgda/issues
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Imports: 
     cli (>= 3.3.0),
     dplyr,
@@ -31,7 +31,7 @@ Imports:
     haven,
     data.table,
     yaml,
-    here,
+    rprojroot,
     crayon,
     forcats,
     assertthat,

--- a/R/find-in-files.R
+++ b/R/find-in-files.R
@@ -20,7 +20,7 @@ find_in_files <- function(.paths, .string, .file_types = c("R", "Rmd", "ctl")){
 
     }
 
-    .out[[gsub(here::here(), "", path.i, fixed = TRUE)]] <- found_in.i
+    .out[[gsub(rprojroot::find_rstudio_root_file(), "", path.i, fixed = TRUE)]] <- found_in.i
 
   }
 

--- a/R/get-base-df.R
+++ b/R/get-base-df.R
@@ -22,7 +22,7 @@ get_base_df <- function(.prev_file, .compare_from_svn){
 
     cur_dir <- getwd()
     on.exit(setwd(cur_dir))
-    setwd(here::here())
+    setwd(rprojroot::find_rstudio_root_file())
 
     base_temp <- tempfile(fileext = ".csv")
 

--- a/R/run-app-bg.R
+++ b/R/run-app-bg.R
@@ -17,7 +17,7 @@
 #'   specified, it is randomly selected from the valid range of dynamic ports.
 #'
 #' @details
-#' Make sure to set `Sys.setenv('MRGDA_SHINY_DEV_LOAD_PATH' = here::here())`
+#' Make sure to set `Sys.setenv('MRGDA_SHINY_DEV_LOAD_PATH' = rprojroot::find_rstudio_root_file())`
 #' if you are in a development setting. This will allow package functions to be
 #' accessible in the background process, which is not an issue when the package
 #' is installed.
@@ -99,7 +99,7 @@ run_app_bg <- function(func, args,
         msgs,
         "",
         "i" = "If you are in a dev environment, make sure you set the environment variable:",
-        " " = "{.code Sys.setenv('MRGDA_SHINY_DEV_LOAD_PATH' = here::here())}."
+        " " = "{.code Sys.setenv('MRGDA_SHINY_DEV_LOAD_PATH' = rprojroot::find_rstudio_root_file())}."
       ))
     }
     Sys.sleep(0.01)

--- a/R/write-derived.R
+++ b/R/write-derived.R
@@ -156,7 +156,7 @@ write_derived <- function(.data, .spec, .file, .comment = NULL, .subject_col = "
 
 
   # Determine and save dependencies -----------------------------------------
-  dependencies <- find_in_files(.paths = c(here::here("script"), here::here("model")), .string = basename(.file))
+  dependencies <- find_in_files(.paths = c(rprojroot::find_rstudio_root_file("script"), rprojroot::find_rstudio_root_file("model")), .string = basename(.file))
   yaml::write_yaml(dependencies, file = file.path(.meta_data_folder, "dependencies.yml"))
 
 

--- a/R/write-derived.R
+++ b/R/write-derived.R
@@ -156,8 +156,21 @@ write_derived <- function(.data, .spec, .file, .comment = NULL, .subject_col = "
 
 
   # Determine and save dependencies -----------------------------------------
-  dependencies <- find_in_files(.paths = c(rprojroot::find_rstudio_root_file("script"), rprojroot::find_rstudio_root_file("model")), .string = basename(.file))
-  yaml::write_yaml(dependencies, file = file.path(.meta_data_folder, "dependencies.yml"))
+  rstudio_proj <- tryCatch(
+    rprojroot::find_rstudio_root_file(),
+    error = identity
+  )
+
+  if (!inherits(rstudio_proj, "error")) {
+    dependencies <-
+      find_in_files(.paths = c(
+        file.path(rstudio_proj, "script"),
+        file.path(rstudio_proj, "model")
+      ),
+      .string = basename(.file))
+
+    yaml::write_yaml(dependencies, file = file.path(.meta_data_folder, "dependencies.yml"))
+  }
 
 
   # Update history ----------------------------------------------------------

--- a/man/run_app_bg.Rd
+++ b/man/run_app_bg.Rd
@@ -37,7 +37,7 @@ Use \code{\link[callr:r_bg]{callr::r_bg()}} to launch the app in a separate proc
 \code{port} on \code{host} is active.
 }
 \details{
-Make sure to set \code{Sys.setenv('MRGDA_SHINY_DEV_LOAD_PATH' = here::here())}
+Make sure to set \code{Sys.setenv('MRGDA_SHINY_DEV_LOAD_PATH' = rprojroot::find_rstudio_root_file())}
 if you are in a development setting. This will allow package functions to be
 accessible in the background process, which is not an issue when the package
 is installed.

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -12,6 +12,7 @@ local_svn_repo <- function(clean = TRUE, env = parent.frame()){
                                clean = clean,
                                .local_envir = env
   )
+  writeLines("Version: 1.0", con = file.path(repo, "temp.Rproj"))
   return(repo)
 }
 
@@ -94,7 +95,7 @@ with_bg_env <- function(code){
   Sys.setenv("MRGDA_SHINY_DEV_LOAD_PATH" = "")
   # Dont run if inside an R CMD Check environment (package is installed)
   if(!testthat::is_checking()){
-    Sys.setenv("MRGDA_SHINY_DEV_LOAD_PATH" = here::here())
+    Sys.setenv("MRGDA_SHINY_DEV_LOAD_PATH" = rprojroot::find_rstudio_root_file())
     Sys.setenv("RSTUDIO" = 1)
     on.exit(Sys.setenv("MRGDA_SHINY_DEV_LOAD_PATH" = ""))
   }

--- a/tests/testthat/test-write-derived.R
+++ b/tests/testthat/test-write-derived.R
@@ -62,7 +62,7 @@ test_that("write_derived gives error if data has comma in any value", {
       values = c(1, 2, 3)
       )
 
-  expect_error(write_derived(.data = df_comma, .spec = nm_spec, .file = .temp_csv))
+  expect_error(write_derived(.data = df_comma, .spec = nm_spec, .file = .temp_csv, .compare_from_svn = FALSE))
 })
 
 test_that("write_derived works with no ID column in data", {
@@ -70,12 +70,12 @@ test_that("write_derived works with no ID column in data", {
   nm_spec$ID <- NULL
   .temp_csv2 <- paste0(tempfile(), ".csv")
 
-  expect_error(write_derived(.data = nm, .spec = nm_spec, .file = .temp_csv2))
+  expect_error(write_derived(.data = nm, .spec = nm_spec, .file = .temp_csv2, .compare_from_svn = FALSE))
 })
 
 test_that("if yspec check fails  write derived does not continue", {
   nm_spec$ADAC <- NULL
-  expect_error(write_derived(.data = nm, .spec = nm_spec, .file =  paste0(tempfile(), ".csv")))
+  expect_error(write_derived(.data = nm, .spec = nm_spec, .file =  paste0(tempfile(), ".csv"), .compare_from_svn = FALSE))
 })
 
 

--- a/tests/testthat/test-write-derived.R
+++ b/tests/testthat/test-write-derived.R
@@ -2,6 +2,7 @@ nm_spec <- yspec::ys_load(system.file("derived", "pk.yml", package = "mrgda"))
 nm <- readr::read_csv(system.file("derived", "pk.csv", package = "mrgda"), na = ".", show_col_types = FALSE)
 
 withr::with_tempdir({
+  writeLines("Version: 1.0", con = "temp.Rproj")
   svn_dir <- local_svn_repo()
   withr::defer(unlink(svn_dir, recursive = TRUE))
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -26,7 +26,7 @@ MeRGE Expo</a>.
 ```{r setup_interactive, include=FALSE}
 if (interactive() || isTRUE(getOption('knitr.in.progress'))) {
   devtools::load_all()
-  Sys.setenv('MRGDA_SHINY_DEV_LOAD_PATH' = here::here())
+  Sys.setenv('MRGDA_SHINY_DEV_LOAD_PATH' = rprojroot::find_rstudio_root_file())
 }
 ```
 
@@ -106,7 +106,7 @@ nm_spec <- yspec::ys_load(system.file("derived", "pk.yml", package = "mrgda"))
 mrgda::write_derived(
   .data = derived$nm,
   .spec = nm_spec,
-  .file = here::here("data", "derived", "pk.csv")
+  .file = rprojroot::find_rstudio_root_file("data", "derived", "pk.csv")
 )
 ```
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -12,6 +12,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+writeLines("Version: 1.0", con = "temp.Rproj")
 ```
 
 # Introduction


### PR DESCRIPTION
`here::here` is only recommended for interactive use, so we will use `rprojroot::find_rstudio_root_file` instead.

The command `writeLines("Version: 1.0", con = "temp.Rproj")` can be used to create a Rproj file (without being in rstudio).