### PR TITLE
release/0.14.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mrgda
 Title: Tools for Data Assembly
-Version: 0.13.0.9011
+Version: 0.14.0
 Authors@R: 
     c(
     person(given = "Eric", family = "Anderson", email = "andersone@metrumrg.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mrgda development
+# mrgda 0.14.0
 
 ## New features and changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,15 @@
 
 ## New features and changes
 
+- `read_src_dir()` now requires `.file_types` to be set explicitly; automatic file type detection was removed. (#249)
 - `query_src_list` now searches across values in addition to column and label names. (#251)
+- `write_derived()` now writes a slimmer metadata folder and no longer keeps the older metadata outputs that were previously generated. (#254)
+- `write_derived()` now avoids regenerating the XPT and define files when the CSV and `spec-list.yml` are unchanged, and writes a human-readable `diff-summary.txt` for data and spec changes. (#255)
+- `annotate_da()` replaces `explain()`, and the vignette/examples were renamed to match. (#256)
+
+## Bug fixes
+
+- `read_src_dir()` now errors clearly when no files of the requested type are found, when requested domains are missing, and when a source file fails to load. (#258)
 
 # mrgda 0.13.0
 


### PR DESCRIPTION
https://github.com/metrumresearchgroup/mrgda/compare/0.13.0...release/0.14.0

```
scores:
{
  "testing": {
    "check": 1,
    "coverage": 0.9807
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```